### PR TITLE
clarify that (if) small PRs can be submitted without issues first

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-When contributing to this project, please first discuss the change you wish to make via [issue](https://github.com/agrdatasci/climatrends/issues) before making a change and pull request. Please submit questions, bug reports, and requests in the issues tracker.
+When contributing to this project, please first discuss the change you wish to make via [issue](https://github.com/agrdatasci/climatrends/issues) before making a change and pull request, unless it is a minor change that doesn't affect package functionality. Please submit questions, bug reports, and requests in the issues tracker.
 
 Note that we have a [code of conduct](https://agrdatasci.github.io/climatrends/CODE_OF_CONDUCT.html), please follow it in all your interactions with the project.
 


### PR DESCRIPTION
- To meet JOSS requirements of 'clear instructions for contributing' https://github.com/openjournals/joss-reviews/issues/4405, instructions in the two sections need to be consistent
- Currently the Pull Request Process section allows small PRs without an issue but the Contributing section does not
- sometimes (like now) it is easier to create the PR and have it serve the function of the issue, so this PR proposes update in that direction!